### PR TITLE
Change webpack configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = {
     port: '6501',
     contentBase: ['./docs'],
     historyApiFallback: true,
+    open: true
   },
   resolve: {
     extensions: ['.js', '.jsx', '.json'],


### PR DESCRIPTION
`open: true` will automatically open the default web browser when the server starts.