### PR TITLE
Added new variant in resume cover named 'MultiComponent'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8816,8 +8816,7 @@
     "msk-themes": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/msk-themes/-/msk-themes-1.0.3.tgz",
-      "integrity": "sha512-ogli0j/Tb2Ck+4/sdHGSsuPyhl5VQkZ5iv+nIRNeXstl0W6paCXYrUIy2adJ8MotZryGgGXKGBlaKCIH2ee53Q==",
-      "dev": true
+      "integrity": "sha512-ogli0j/Tb2Ck+4/sdHGSsuPyhl5VQkZ5iv+nIRNeXstl0W6paCXYrUIy2adJ8MotZryGgGXKGBlaKCIH2ee53Q=="
     },
     "multicast-dns": {
       "version": "6.2.3",

--- a/src/modules/resume/cover/variants/index.js
+++ b/src/modules/resume/cover/variants/index.js
@@ -1,9 +1,11 @@
 import Basic from './basic/index.js';
 import Dense from './dense/index.js';
 import Modern from './modern/index.js';
+import MultiComponent from './multiComponent/index.js';
 
 export default {
   Basic,
   Dense,
-  Modern
+  Modern,
+  MultiComponent,
 };

--- a/src/modules/resume/cover/variants/multiComponent/contributors.js
+++ b/src/modules/resume/cover/variants/multiComponent/contributors.js
@@ -1,0 +1,9 @@
+const contributors = [
+    {
+      name: "Lavish Jain",
+      email: "lavishrjain1997@gmail.com",
+      url: "https://github.com/lavish-jain"
+    }
+  ]
+  
+  export default contributors;

--- a/src/modules/resume/cover/variants/multiComponent/index.js
+++ b/src/modules/resume/cover/variants/multiComponent/index.js
@@ -1,0 +1,11 @@
+import render from './render'
+import properties from './properties'
+import metadata from './metadata'
+import contributors from './contributors'
+
+export default {
+  render,
+  properties,
+  metadata,
+  contributors
+}

--- a/src/modules/resume/cover/variants/multiComponent/metadata.js
+++ b/src/modules/resume/cover/variants/multiComponent/metadata.js
@@ -1,0 +1,7 @@
+
+const metadata = {
+    name: "Seperate Image cover",
+    description: "A cover with profile image over complementary background",
+  }
+  
+  export default metadata;

--- a/src/modules/resume/cover/variants/multiComponent/properties.js
+++ b/src/modules/resume/cover/variants/multiComponent/properties.js
@@ -1,0 +1,49 @@
+import propertyTypes from 'msk-property-types'
+import themes from 'msk-themes'
+
+const properties = {
+  theme: {
+    name: 'Theme',
+    type: propertyTypes.THEME,
+    value: themes.dark.shadowPurple,
+    required: true
+  },
+  name: {
+    name: 'Name',
+    type: propertyTypes.STRING,
+    value: 'hello',
+    required: true
+  },
+  imageUrl: {
+    name: 'Image URL',
+    type: propertyTypes.STRING,
+    value: 'https://mskdocuments.com/images/favicon.png',
+    required: false
+  },
+  designation: {
+    name: 'Designation',
+    type: propertyTypes.STRING,
+    value: 'Designation',
+    required: false
+  },
+  company: {
+    name: 'Company',
+    type: propertyTypes.STRING,
+    value: 'Company name',
+    required: false
+  },
+  emailId: {
+    name: 'Email ID',
+    type: propertyTypes.EMAIL,
+    value: 'Email ID',
+    required: true
+  },
+  phoneNo: {
+    name: 'Phone No',
+    type: propertyTypes.NUMBER,
+    value: '9999999999',
+    required: true
+  },
+};
+
+export default properties;

--- a/src/modules/resume/cover/variants/multiComponent/render.js
+++ b/src/modules/resume/cover/variants/multiComponent/render.js
@@ -1,0 +1,107 @@
+import React from 'react'
+const useStyles = () => ({
+    root: {
+        display: 'flex'
+    },
+    coverDiv: {
+        width: '60%'
+    },
+    detailsWrapper: {
+        padding: 20,
+        textAlign: 'left',
+        display: 'inline-block'
+    },
+    avatarWrapper: {
+        width: '40%',
+        padding: 10,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+    },
+    avatarImage: {
+        display: 'block',
+        margin: 'auto',
+        width: '100%',
+        maxWidth: 200,
+        height: 'auto',
+        borderRadius: '50%',
+    },
+    name: {
+        margin: 0,
+        fontSize: 40,
+        fontWeight: 'bold'
+    },
+    designation: {
+        margin: 0
+    },
+    company: {
+        margin: 0
+    },
+    contactDetails: {
+        marginTop: 10
+    },
+    emailId: {
+
+    },
+    phoneNo: {
+
+    },
+    contactDetailsItemLabel: {
+        fontWeight: 'bold',
+    }
+})
+
+export default (
+    {
+        theme,
+        name,
+        designation,
+        company,
+        emailId,
+        phoneNo,
+        imageUrl
+    }
+) => {
+    const styles = useStyles()
+    return (
+        <div style={styles.root}>
+            <div style={{
+                ...styles.avatarWrapper,
+                backgroundColor: theme.value.contrast}}>
+                <img style={{
+                    ...styles.avatarImage,
+                    border: `5px solid ${theme.value.color}`
+                }} src={imageUrl.value} />
+            </div>
+
+            <div
+                style={{
+                    ...styles.coverDiv,
+                    backgroundColor: theme.value.color,
+                    color: theme.value.contrast
+                }}
+            >
+
+                <div style={styles.detailsWrapper}>
+                    <div style={styles.name} >{name.value}</div>
+                    <h3 style={styles.designation}>{designation.value}</h3>
+                    <h4 style={styles.company}>{company.value}</h4>
+
+                    <div style={styles.contactDetails} >
+                        {emailId.value && <div>
+                            <span style={styles.contactDetailsItemLabel}>Email: </span><span style={styles.emailId}>{emailId.value}</span>
+                        </div>}
+                        {phoneNo.value && <div>
+                            <span style={styles.contactDetailsItemLabel}>Ph: </span><span style={styles.phoneNo}>{phoneNo.value}</span>
+                        </div>}
+                    </div>
+
+                </div>
+
+
+
+            </div>
+
+        </div >
+    );
+};


### PR DESCRIPTION
Added a new variant (named 'MultiComponent') in resume covers where the user's photo and their details are in separate divs with complementary color backgrounds (theme.value.contrast and theme.value.color)

![rsz_screenshot_from_2020-07-26_23-28-43](https://user-images.githubusercontent.com/30045136/88486046-6b46c480-cf98-11ea-807b-f0264d8863d1.png)
![rsz_screenshot_from_2020-07-26_23-28-37](https://user-images.githubusercontent.com/30045136/88486047-6c77f180-cf98-11ea-8340-f8ea84a6b8c4.png)
